### PR TITLE
post job status to commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
-dist:
-  - xenial
-
 sudo: required
-
 language: bash
-
 install: true
-
+script: true
+after_script: ./script.sh
+env:
+  global:
+    # GH_TOKEN: repo:status token 
+    - secure: Y/b/hHSyS1tQRJfF2hqN80wY2YfdN7/OinRCyxT+cSnoW8gMlEiKGMGhpMYfPPKGZY77yl8GAFh0tq/Hy8u2/nqEt80e6LQvQSJZAoh8yhzG2L7jhsxBHzFM0YVEYhMiffgBuDULKsjaiVXwNT4s1ConexcoD7GLY2G698XrfXIGqdHKL1OQA9tVmhXx+MeL4/QN/KmPxLo2VhdBHBzE35Y64RKf7jcusGzQKAFIf3RYVCV2lXMz7OhbSNoXC5kA6R09PVKfay8a4lSCCQ9+EllFfSzkuRE5M+oKZ0KvoT+lyTms7JIlUTR8VVle8eIjKZdPcB1J9o+dE2JU5e4+4yXxdb96PfPWlex27d82kU9g9A/E0E5ReFT6UFSBO8MiVFsUgf5qiWgp3dASMR9TR34m8X8AH6ibu1fxE2O5one89LhlxWIThuRamX0ovZ0YTnTQQsMDrbjnPa2dUWhpbFj9fU12kcosOGIQheL9xlatkjDOg7otMeMG0vv9kPfBC/bKk9ArlJSSrVl3lR1tsNK0UWd7WYykmYSQiRv+PHEGU9j+oG/e1BB3hQ2gVtr5WEerPekp752+wbZDDm2n0HzZTjaoaeGe8Nd9zDpEuQbR92S9qkes/un9dzoAZiCXdhzobuZ1trR6b9eWdmCxMjMPmlpxvLzmmwDapTUsNJw=
+  matrix: 
+    # run a different set of tests based on the env var in the matrix
+    - test_process=first
+    - test_process=second
+    - test_process=third
+    - test_process=fourth

--- a/script.sh
+++ b/script.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
-echo counting script
-for i in `seq 1 100000`;
-do	
-	if (( $i % 10000 == 0 )) ; 
-	then
-		echo $i
-	fi
-done
+#!/bin/bash
 
-echo sleeping 1 minute
-sleep 1m
+echo test process: $test_process
 
-echo done
+if [ $TRAVIS_TEST_RESULT -eq 0 ]; then
+    job_result=success
+else 
+    job_result=failure
+fi
+
+body='{
+    "state": "'${job_result}'",
+    "description": "travis-ci-tests",
+    "target_url": "https://travis-ci.org/acnagy/sketchbook/jobs/'${TRAVIS_JOB_ID}'",
+    "context": "'${test_process}'"
+}'
+
+curl -X POST "https://api.github.com/repos/acnagy/sketchbook/statuses/${TRAVIS_COMMIT}" \
+-H "Accept: application/vnd.github.v3+json" \
+-H "Authorization: token ${GH_TOKEN}" \
+-d "$body"


### PR DESCRIPTION
.travis.yml + bash script to post the results of a Travis job back to a commit using the [GitHub combined statuses API](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref). 